### PR TITLE
Fix for potential issue retrieving policies from rego

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,8 @@
 
 - Fixes to FIWARE headers
 - Prevented creation of duplicate policies
+- Fixed potential issue with retrieving policies from rego that causes 403
+  responses
 
 ### Documentation
 

--- a/config/envoy/v3.yaml
+++ b/config/envoy/v3.yaml
@@ -23,6 +23,26 @@ static_resources:
                 route:
                   cluster: upstream-service
           http_filters:
+          - name: envoy.filters.http.lua
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inline_code: |
+                function envoy_on_request(request_handle)
+                  local policies_headers, policies_body = request_handle:httpCall(
+                  "policyapi-service",
+                  {
+                    [":method"] = "GET",
+                    [":path"] = "/v1/policies/",
+                    [":authority"] = request_handle:headers():get(":authority"),
+                    ["accept"] = "text/rego",
+                    ["fiware-service"] = request_handle:headers():get("fiware-service"),
+                    ["fiware-servicepath"] = request_handle:headers():get("fiware-servicepath"),
+                  },
+                  nil,
+                  5000,
+                  false)
+                  request_handle:headers():add("policies", policies_body)
+                end
           - name: envoy.ext_authz
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
@@ -78,6 +98,26 @@ static_resources:
                 function envoy_on_request(request_handle)
                   request_handle:headers():add("fiware_service", request_handle:headers():get("fiware-Service"))
                   request_handle:headers():add("fiware_service_path", request_handle:headers():get("fiware-Servicepath"))
+                end
+          - name: envoy.filters.http.lua
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inline_code: |
+                function envoy_on_request(request_handle)
+                  local policies_headers, policies_body = request_handle:httpCall(
+                  "policyapi-service",
+                  {
+                    [":method"] = "GET",
+                    [":path"] = "/v1/policies/",
+                    [":authority"] = request_handle:headers():get(":authority"),
+                    ["accept"] = "text/rego",
+                    ["fiware-service"] = request_handle:headers():get("fiware-service"),
+                    ["fiware-servicepath"] = request_handle:headers():get("fiware-servicepath"),
+                  },
+                  nil,
+                  5000,
+                  false)
+                  request_handle:headers():add("policies", policies_body)
                 end
           - name: envoy.filters.http.ext_authz
             typed_config:

--- a/config/opa-service/rego/common.rego
+++ b/config/opa-service/rego/common.rego
@@ -5,6 +5,7 @@ import future.keywords.in
 import input.attributes.request.http.method as method
 import input.attributes.request.http.path as path
 import input.attributes.request.http.headers.authorization as authorization
+import input.attributes.request.http.headers.policies as input_policies
 
 # Action to method mappings
 scope_method := {"acl:Read": ["GET"], "acl:Write": ["POST"], "acl:Control": ["PUT", "DELETE"]}
@@ -54,7 +55,8 @@ jwks_request(url) = http.send({
 })
 
 # Grab data from API
-data = http.send({"method": "get", "url": api_uri, "headers": {"accept": "text/rego", "fiware-service": request.tenant, "fiware-servicepath": request.service_path}}).body
+# data = http.send({"method": "get", "url": api_uri, "headers": {"accept": "text/rego", "fiware-service": request.tenant, "fiware-servicepath": request.service_path}}).body
+data = json.unmarshal(input_policies)
 
 # The user/subject
 subject := p {


### PR DESCRIPTION
## Proposed changes

Sometimes, due to automatic performance optimizations done by OPA, the http.send function in rego isn't carried out, causing policies not to be retrieved and resulting in 403 responses.

Moving the retrieval of the policies to a lua filter in the envoy and passing it to opa ensured this doesn't happen anymore.

## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask. We're here to help! This is simply a reminder of what we are going
to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [Contributor License Agreement][cla]
- [x] I have updated the [RELEASE NOTES][release]
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in
      downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc...




[cla]: https://raw.githubusercontent.com/orchestracities/anubis/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/anubis/blob/master/CONTRIBUTING.md
    "Contributing to Anubis"
[release]: https://github.com/orchestracities/anubis/blob/master/RELEASE_NOTES.md
    "Anubis Release Notes"
