### PR TITLE
fix issue with / in the group name

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 
 ### Bug fixes
 
+- Fix support for groups including `/` in the name
 - Change the keycloak config file to manage the token refresh
 - Missing database entry for oc-acl:Delete
 - Correct parsing / serialisation of policies (still something to be checked)

--- a/anubis-management-api/anubis/default.py
+++ b/anubis-management-api/anubis/default.py
@@ -30,4 +30,4 @@ DEFAULT_AGENT_TYPES = [
     AGENT_GROUP_IRI
 ]
 AGENT_IRI_REGEX = "^" + AGENT_CLASS_IRI + \
-    r":[a-zA-Z0-9_\-]+$" + "|^" + AGENT_GROUP_IRI + r":[a-zA-Z0-9_\-]+$" + "|^" + AGENT_IRI + r":[a-zA-Z0-9_\-\@\.]+$"
+    r":[a-zA-Z0-9_\-]+$" + "|^" + AGENT_GROUP_IRI + r":[a-zA-Z0-9_\-\/]+$" + "|^" + AGENT_IRI + r":[a-zA-Z0-9_\-\@\.]+$"

--- a/anubis-management-api/anubis/tests/test_policies.py
+++ b/anubis-management-api/anubis/tests/test_policies.py
@@ -75,6 +75,21 @@ def test_policies(test_db):
     policy_id = response.headers["Policy-ID"]
     assert policy_id
 
+    # test group policy
+    response = client.post(
+        "/v1/policies/",
+        headers={
+            "fiware-service": "test",
+            "fiware-servicepath": "/"},
+        json={
+            "access_to": "resource:foobar:bar",
+            "resource_type": "entity",
+            "mode": ["acl:Read"],
+            "agent": ["acl:agentGroup:/Admin/Test"]})
+    assert response.status_code == 201
+    policy_id = response.headers["Policy-ID"]
+    assert policy_id
+
     # test policy creation without servicePath
     response = client.post(
         "/v1/policies/",
@@ -108,7 +123,7 @@ def test_policies(test_db):
             "fiware-servicepath": "/"})
     assert response.status_code == 200
     body = response.json()
-    assert len(body) == 10
+    assert len(body) == 11
 
     response = client.get(
         "/v1/policies/",
@@ -125,7 +140,7 @@ def test_policies(test_db):
             "fiware-service": "test"})
     assert response.status_code == 200
     body = response.json()
-    assert len(body) == 11
+    assert len(body) == 12
 
     response = client.get(
         "/v1/policies/?agent_type=acl:agent",
@@ -143,7 +158,7 @@ def test_policies(test_db):
             "fiware-servicepath": "/"})
     body = response.json()
     assert response.status_code == 200
-    assert len(body) == 2
+    assert len(body) == 3
 
     response = client.get(
         "/v1/policies/?resource_type=entity",
@@ -152,7 +167,7 @@ def test_policies(test_db):
             "fiware-servicepath": "/"})
     body = response.json()
     assert response.status_code == 200
-    assert len(body) == 9
+    assert len(body) == 10
 
     response = client.get(
         "/v1/policies/?resource_type=entity&agent_type=acl:agent",
@@ -170,7 +185,7 @@ def test_policies(test_db):
             "fiware-servicepath": "/"})
     body = response.json()
     assert response.status_code == 200
-    assert len(body) == 2
+    assert len(body) == 3
 
     response = client.get(
         "/v1/policies/?resource_type=entity&agent_type=acl:agent&resource=resource",


### PR DESCRIPTION
## Proposed changes

Keycloak defines groups as a tree, so the best way to identify them is a path.
So far `/` was excluded from the group name, but this triggers errors when
groups are created from Keycloak paths.

## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask. We're here to help! This is simply a reminder of what we are going
to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [Contributor License Agreement][cla]
- [x] I have updated the [RELEASE NOTES][release]
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in
      downstream modules

## Further comments

N/A


[cla]: https://raw.githubusercontent.com/orchestracities/anubis/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/anubis/blob/master/CONTRIBUTING.md
    "Contributing to Anubis"
[release]: https://github.com/orchestracities/anubis/blob/master/RELEASE_NOTES.md
    "Anubis Release Notes"
