### PR TITLE
Add a simple bash script to allow for the creation of a FIWARE clone

### DIFF
--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -1,0 +1,39 @@
+set -e
+
+SOURCE="orchestracities/anubis-management-api"
+DOCKER_TARGET="fiware/anubis"
+QUAY_TARGET="quay.io/fiware/anubis"
+
+# DOCKER_TARGET="fiware/$(basename $(git rev-parse --show-toplevel))"
+# QUAY_TARGET="quay.io/fiware/$(basename $(git rev-parse --show-toplevel))"
+
+VERSION=$(git describe --exclude 'FIWARE*' --tags $(git rev-list --tags --max-count=1))
+
+function clone {
+   echo 'cloning from '"$1 $2"' to '"$3"
+   docker pull -q "$1":"$2"
+   docker tag "$1":"$2" "$3":"$2"
+   docker push -q "$3":"$2"
+   
+   if ! [ -z "$4" ]; then
+        echo 'pushing '"$1 $2"' to latest'
+        docker tag "$1":"$2" "$3":latest
+        docker push -q "$3":latest
+   fi
+}
+
+for i in "$@" ; do
+    if [[ $i == "docker" ]]; then
+        clone "$SOURCE" "$VERSION" "$DOCKER_TARGET" true
+    fi
+    if [[ $i == "quay" ]]; then
+        clone "$SOURCE" "$VERSION" "$QUAY_TARGET" true
+    fi
+    echo ""
+done
+
+for i in "$@" ; do
+    if [[ $i == "clean" ]]; then
+        docker rmi -f $(docker images -a -q) | true
+    fi
+done

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![FIWARE Security](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/security.svg)](https://www.fiware.org/developers/catalogue/)
 [![License: APACHE-2.0](https://img.shields.io/github/license/orchestracities/anubis.svg)](https://opensource.org/licenses/APACHE-2.0)
-[![Docker Status](https://img.shields.io/docker/pulls/orchestracities/anubis-management-api.svg)](https://hub.docker.com/r/orchestracities/anubis-management-api)
+[![Docker badge](https://img.shields.io/badge/quay.io-fiware%2Fanubis-grey?logo=red%20hat&labelColor=EE0000)](https://quay.io/repository/fiware/anubis)
 [![Support](https://img.shields.io/badge/support-ask-yellowgreen.svg)](https://github.com/orchestracities/anubis/issues)
 [![Documentation badge](https://img.shields.io/readthedocs/anubis-pep.svg)](https://anubis-pep.readthedocs.io/en/latest/)
 
 Welcome to Anubis!
 
-| :books: [Documentation](https://anubis-pep.readthedocs.io/en/latest/) | :whale: [Docker Hub](https://hub.docker.com/r/orchestracities/anubis-management-api) |
+| :books: [Documentation](https://anubis-pep.readthedocs.io/en/latest/) |   <img style="height:1em" src="https://quay.io/static/img/quay_favicon.png"/> [quay.io](https://quay.io/repository/fiware/anubis) |
 | ------------- | ---------------|
 
 ## What is the project about?


### PR DESCRIPTION
## Proposed changes

As discussed within the TSC, FIWARE Foundation need to be able to create clones of the container image on both Docker Hub and quay.io - this PR allows us to continue to track your latest container images, a functionality which has been removed from the free tier on Docker Hub.

## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask. We're here to help! This is simply a reminder of what we are going
to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [Contributor License Agreement][cla]
- [ ] I have updated the [RELEASE NOTES][release]
- [ ] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in
      downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc...




[cla]: https://raw.githubusercontent.com/orchestracities/anubis/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/anubis/blob/master/CONTRIBUTING.md
    "Contributing to Anubis"
[release]: https://github.com/orchestracities/anubis/blob/master/RELEASE_NOTES.md
    "Anubis Release Notes"
